### PR TITLE
chore: bump minimal-mistakes to v4.24.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,7 +59,7 @@ include:
 
 # Build settings
 markdown: kramdown
-remote_theme: "mmistakes/minimal-mistakes@4.22.0"
+remote_theme: "mmistakes/minimal-mistakes@4.24.0"
 # theme: minimal-mistakes-jekyll
 
 plugins:


### PR DESCRIPTION
Upgrade theme to latest version.
